### PR TITLE
do not join with base if it's a absolute url

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -62,6 +62,9 @@ function isFeedLink (originUrl, base, tagName, attrs) {
     var type = attrs.type || attrs.TYPE;
 
     if (href && tagName == 'link' && inc(contentTypes, type)) {
+        if (href.indexOf('http') === 0 || href.indexOf('//') === 0 ) {
+          return url.resolve(originUrl, href);
+        }
         return url.resolve(originUrl, base ? path.join(base, href) : href);
     }
 }
@@ -74,6 +77,9 @@ function isPossiblyFeed (originUrl, base, tagName, attrs) {
     var href = attrs.href || attrs.HREF;
 
     if (inc(['a', 'link'], tagName) && feedLike.test(href) && !blacklist.test(href)) {
+        if (href.indexOf('http') === 0 || href.indexOf('//') === 0 ) {
+          return url.resolve(originUrl, href);
+        }
         return url.resolve(originUrl, base ? path.join(base, href) : href);
     }
 }


### PR DESCRIPTION
Some html of blogs may contain a `<base>` tag and a feed `<a>` tag with an absolute url. (no `<link>` tag)
for example: `https://www.alloc-init.com/`
```html
<base href="/"/>
...
<a href="https://alloc-init.com/feed">rss</a>
```

For this case, the API returns a feed link like this:
`https://www.alloc-init.com/https:/alloc-init.com/feed`

This PR resolves this issue.