### PR TITLE
use final url after redirects

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -18,6 +18,9 @@ function parser(url, cb) {
     request(url, function (err, data, response) {
         if (err) return cb(); // ignore error
         var base = null;
+        if (response.url) {
+          url = response.url;
+        }
 
         // strip content-type extra info like 'text/xml; charset=utf-8'
         var header = (response.headers['content-type'] || '').split(';')[0];

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/cakuki/feed-finder#readme",
   "dependencies": {
-    "got": "^5.6.0",
+    "got": "^5.7.1",
     "htmlparser2": "^3.9.0"
   }
 }


### PR DESCRIPTION
use the final url after redirects, so we can get the correct url if we get redirected.

got@5.7.1 have fixed a response.url related issue. (https://github.com/sindresorhus/got/commits/v5.7.1)